### PR TITLE
created feature that enables the user to choose which parametes he wa…

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,23 @@ import * as d3 from 'd3';
 const globeContainer = document.getElementById('globeViz');
 
 const colorScale = d3.scaleSequentialPow(d3.interpolateOrRd).exponent(1 / 4);
-const getVal = (feat) => feat.covid.cases;
+
+const countriesWithCovid = [];
+
+let colorMethod = "Total";
+
+const getVal = (feat) => {
+  if(colorMethod == "Active"){
+    return feat.covid.active;
+  }
+  else if(colorMethod == "Deaths"){
+    return feat.covid.deaths;
+  }
+  else if(colorMethod == "Recovered"){
+    return feat.covid.recovered;
+  }
+  return feat.covid.cases;
+}; 
 
 let world;
 
@@ -71,8 +87,6 @@ async function getCases() {
   const countries = await request(GEOJSON_URL);
   const data = await request(CASES_API);
 
-  const countriesWithCovid = [];
-
   data.forEach((item) => {
     const countryIdxByISO = countries.features.findIndex(
       (i) =>
@@ -106,6 +120,11 @@ async function getCases() {
   world.polygonsData(countriesWithCovid);
   document.querySelector('.title-desc').innerHTML =
     'Hover on a country or territory to see cases, deaths, and recoveries.';
+
+  document.getElementById("total-button").onclick = changeColorScaleMethod;
+  document.getElementById("active-button").onclick = changeColorScaleMethod;
+  document.getElementById("deaths-button").onclick = changeColorScaleMethod;
+  document.getElementById("recovered-button").onclick = changeColorScaleMethod;
 
   // Show total counts
   showTotalCounts(data);
@@ -145,6 +164,31 @@ function showTotalCounts(data) {
   const totalRecovered = data.reduce((a, b) => a + b.recovered, 0);
   const recovered = new CountUp('recovered', totalRecovered);
   recovered.start();
+}
+
+function changeColorScaleMethod(element) {
+  colorMethod = element.srcElement.innerText;
+
+  const colorMap = {
+    Total: "orange",
+    Active: "yellow",
+    Deaths: "red",
+    Recovered: "green"
+  };
+
+  const buttons = document.getElementsByClassName("config-button");
+
+  for(let i=0; i < buttons.length; i+=1){
+      if(buttons[i].innerText != colorMethod){
+        buttons[i].classList = ['config-button'];
+      } else {
+        buttons[i].classList = ['config-button ' + colorMap[colorMethod]];
+      }
+  }
+
+  const maxVal = Math.max(...countriesWithCovid.map(getVal));
+  colorScale.domain([0, maxVal]);
+  world.polygonsData(countriesWithCovid);
 }
 
 // Responsive globe

--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,21 @@
     </div>
 
     <div class="bottom-info-container">
+      <div class="color-options-container">
+        <div> Color visualization by:</div>
+        <button id='total-button' class="config-button orange">
+          Total 
+        </button>
+        <button id='active-button' class="config-button">
+           Active 
+        </button>
+        <button id='deaths-button' class="config-button"> 
+          Deaths 
+        </button>
+        <button id='recovered-button' class="config-button"> 
+          Recovered 
+        </button>
+      </div>
       <div style="font-size: 14px; color: #ccd6f6;">
         Total Counts <span class="updated"></span>
       </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18,6 +18,30 @@ body {
   width: 100%;
 }
 
+.config-button {
+  padding: 4px;
+}
+
+.config-button.orange {
+  color:white;
+  background-color: goldenrod;
+}
+
+.config-button.yellow {
+  color:black;
+  background-color: lightgoldenrodyellow;
+}
+
+.config-button.red {
+  color:white;
+  background-color: #ff4848;
+}
+
+.config-button.green {
+  color:white;
+  background-color: #1ae021;
+}
+
 .bottom-info-container {
   z-index: 1;
   bottom: 20px;


### PR DESCRIPTION
When i visited the site for the first time, i missed being able to see the heat map of the countries by other parameters, and not only by the total number of confirmed cases. So I created a configuration line in the interface, with 4 buttons:

- Total (total number of confirmed cases)

- Active (total number of active cases)

- Deaths (total number of deaths)

- Recovered (total number of recovery cases)

And clicking on the respective button makes the color scale on the map adjust according to the chosen option.

Perhaps the design was not so in line with the rest of the site, but I think it is worth adding this feature.

An example photo of the result can be found at:

https://gyazo.com/a95057de5b938afe587aa61949f8e567

Any suggestions on how to improve the interface or code changes is welcome!